### PR TITLE
Increase default adapt_delta

### DIFF
--- a/R/stan_nbbp.R
+++ b/R/stan_nbbp.R
@@ -44,7 +44,8 @@
 #' @param mu_r_eff location parameter of Lognormal prior on r_eff (prior mean(log(r_eff))).
 #' @param sigma_r_eff scale parameter of Lognormal prior on r_eff (prior sd(log(r_eff))).
 #' @param sigma_inv_sqrt_dispersion scale of HalfNormal prior on 1 / sqrt(dispersion).
-#' @param iter number of iterations for rstan::sampling.
+#' @param iter number of iterations for rstan::sampling, default of 5000 intends to be conservative.
+#' @param control list for rstan::sampling, default attempts to set adapt_delta conservatively.
 #' @param ... further values past to rstan::sampling.
 #'
 #' @return an rstan stan_fit object
@@ -57,6 +58,7 @@ fit_nbbp_homogenous_bayes <- function(
     sigma_r_eff = 0.421404,
     sigma_inv_sqrt_dispersion = 1.482602,
     iter = 5000,
+    control = list(adapt_delta = 0.9),
     ...) {
   sdat <- .stan_data_nbbp_homogenous(
     all_outbreaks = all_outbreaks,
@@ -69,7 +71,7 @@ fit_nbbp_homogenous_bayes <- function(
     likelihood = TRUE
   )
 
-  return(rstan::sampling(stanmodels$nbbp_homogenous, sdat, iter = iter, ...))
+  return(rstan::sampling(stanmodels$nbbp_homogenous, sdat, iter = iter, control = control, ...))
 }
 
 

--- a/man/fit_nbbp_homogenous_bayes.Rd
+++ b/man/fit_nbbp_homogenous_bayes.Rd
@@ -12,6 +12,7 @@ fit_nbbp_homogenous_bayes(
   sigma_r_eff = 0.421404,
   sigma_inv_sqrt_dispersion = 1.482602,
   iter = 5000,
+  control = list(adapt_delta = 0.9),
   ...
 )
 }
@@ -29,7 +30,9 @@ see details.}
 
 \item{sigma_inv_sqrt_dispersion}{scale of HalfNormal prior on 1 / sqrt(dispersion).}
 
-\item{iter}{number of iterations for rstan::sampling.}
+\item{iter}{number of iterations for rstan::sampling, default of 5000 intends to be conservative.}
+
+\item{control}{list for rstan::sampling, default attempts to set adapt_delta conservatively.}
 
 \item{...}{further values past to rstan::sampling.}
 }


### PR DESCRIPTION
This PR increases the `adapt_delta` passed to `rstan` from `rstan`'s default 0.8 to a nominally more conservative 0.9.

The 0.95 used by rstanarm makes analysis of the pneumonic plague example data with censoring cripplingly slow, but 0.9 does appear sufficient to smooth the occasional MCMC wrinkle out compared to 0.8.