### PR TITLE
Resolve #7

### DIFF
--- a/vignettes/nbbp.Rmd
+++ b/vignettes/nbbp.Rmd
@@ -196,7 +196,8 @@ lnl_surface |>
 ```
 
 The likelihood increases as $R$ decreases, but once $R$ gets small, for a fixed $R$ the likelihood appears to be constant in $k$.
-The presence of this ridge, rather than a single mode, likely explains the convergence difficulties
+The presence of this ridge shape, rather than a single mode, likely explains the convergence difficulties we saw with maximum likelihood estimation.
+For sufficiently small $R$, we can pick any $k$ and not change the likelihood, so the value of $k$ the optimizer ends up giving us is going to depend a lot on where it started.
 
 # "Is $R$ different?"
 
@@ -253,10 +254,17 @@ r_df |>
 The posterior distributions on $R$ exhibit rather low overlap, suggesting that $R$ is in fact different.
 
 We can quantify this, if we like, by some measure of overlap of the posteriors.
-The percent of the posterior on $R$ for the US which is above the 2.5th percentile of the posterior on $R$ for Canada is `r {round(mean(r_df |> dplyr::filter(location == "US") |> dplyr::pull(r) >= r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) |> quantile(probs = 0.025)), 2) * 100}`.
-And the percent of the posterior on $R$ for Canada which is below the 97.5th percentile of the posterior on $R$ for the US is `r {round(mean(r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) <= r_df |> dplyr::filter(location == "US") |> dplyr::pull(r) |> quantile(probs = 0.975)), 2) * 100}`.
-Or for a symmetric summary, we can try to find $\alpha$ and $q$ such that $\text{Pr}(R_{\text{US}} > q \mid \text{data}) = \text{Pr}(R_{\text{Canada}} \leq q \mid \text{data}) = \alpha$.
-(This is equivalent to finding $q$ such that $\text{Pr}(R_{\text{US}} \leq q \mid \text{data}) + \text{Pr}(R_{\text{Canada}} \leq q \mid \text{data}) = 1$, and we can use either posterior to then compute $\alpha$.)
+We might, for example, contemplate what percent  of the posterior on $R_{\text{US}}$ is above the 2.5th percentile of the posterior on $R_{\text{Canada}}$.
+We would then compute the 2.5th percentile of $R_{\text{Canada}}$, find that it is `r {unname(round(r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) |> quantile(probs = 0.025), 2))}`, and count the percent of samples of $R_{\text{US}}$ which are larger than this and find that it is `r {round(mean(r_df |> dplyr::filter(location == "US") |> dplyr::pull(r) >= r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) |> quantile(probs = 0.025)), 2) * 100}`%.
+Or we could do this the other way around, and ask what percent  of the posterior on $R_{\text{Canada}}$ is below the which is below the 97.5th percentile of the posterior on $R_{\text{US}}$.
+This is `r {round(mean(r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) <= r_df |> dplyr::filter(location == "US") |> dplyr::pull(r) |> quantile(probs = 0.975)), 2) * 100}`%.
+
+These summaries are not entirely satisfying, as we have both an arbitrary reference quantile and an asymmetric measure.
+We could instead try to define, jointly, a single probability $\alpha$ and corresponding quantile $q$ such that $\text{Pr}(R_{\text{US}} > q \mid \text{data}) = \text{Pr}(R_{\text{Canada}} \leq q \mid \text{data}) = \alpha$.
+That is, find the value of $R$ for which the posterior probability that $R_{\text{US}}$ is larger is equal to the posterior probability that $R_{\text{Canada}}$ is smaller.
+Since $\text{Pr}(R_{\text{US}} \leq q \mid \text{data}) = 1 - \text{Pr}(R_{\text{US}} > q \mid \text{data})$, we can rearrange this equation and remove $\alpha$, simply writing $\text{Pr}(R_{\text{US}} \leq q \mid \text{data}) + \text{Pr}(R_{\text{Canada}} \leq q \mid \text{data}) = 1$.
+Once we solve for $q$, we get our overlap percent ($\alpha \times 100$%) for free and can estimate it from our samples of either the posterior on $R_{\text{US}}$ or on $R_{\text{Canada}}$.
+This can't simply be done in one chain of `dplyr` calls, so we will need to write some code.
 
 ```{r}
 find_overlap <- function(r_small, r_large) {

--- a/vignettes/nbbp.Rmd
+++ b/vignettes/nbbp.Rmd
@@ -166,27 +166,37 @@ lnl_surface |>
   geom_tile() +
   scale_x_continuous(trans = "log") +
   scale_y_continuous(trans = "log") +
+  xlab("R") +
   scale_fill_viridis_c(option = "magma")
 ```
 
-Here we see that the likelihood surface increases towards both $R = 0$ and $k = 0$.
 Roughly speaking, the region where the log-likelihood is within 12 units of the maximum value is within a bivariate confidence region.
-So we can see there is extensive uncertainty here, and a ridge (which is likely the source of our convergence issues).
-We can focus in on this ridge like so.
+We can see there is extensive uncertainty here, as most of this plot is within a 12 log-likelihood unit range of the maximum.
+
+We also see that the the log-likelihood surface does not appear to have a single mode.
+It is easier to see what is going on if we focus in on where the likelihood is highest.
 
 ```{r}
+r_vec <- exp(seq(log(1e-4), log(0.02), length.out = 100))
+
+lnl_surface <- compute_likelihood_surface(
+  borealpox,
+  r_grid = r_vec,
+  k_grid = k_vec
+)
+
 lnl_surface |>
-  dplyr::mutate(
-    log_dens = ifelse(log_dens >= max(log_dens) - 1, log_dens, NA)
-  ) |>
   ggplot(aes(x = r, y = k, fill = log_dens)) +
   theme_minimal() +
   geom_tile() +
   scale_x_continuous(trans = "log") +
   scale_y_continuous(trans = "log") +
-  scale_fill_viridis_c(option = "magma") +
-  xlab("R")
+  xlab("R") +
+  scale_fill_viridis_c(option = "magma")
 ```
+
+The likelihood increases as $R$ decreases, but once $R$ gets small, for a fixed $R$ the likelihood appears to be constant in $k$.
+The presence of this ridge, rather than a single mode, likely explains the convergence difficulties
 
 # "Is $R$ different?"
 
@@ -291,7 +301,6 @@ rstan::check_hmc_diagnostics(before)
 
 rstan::summary(before)$summary[, c("n_eff", "Rhat")]
 ```
-We see one divergent transition, which `rstan` would prefer was not present, but which should not trouble us.
 
 ```{r}
 rstan::check_hmc_diagnostics(after)

--- a/vignettes/nbbp.Rmd
+++ b/vignettes/nbbp.Rmd
@@ -170,11 +170,11 @@ lnl_surface |>
   scale_fill_viridis_c(option = "magma")
 ```
 
-Roughly speaking, the region where the log-likelihood is within 12 units of the maximum value is within a bivariate confidence region.
+Roughly speaking, by [Wilks' theorem](https://en.wikipedia.org/wiki/Wilks%27_theorem) the region where the log-likelihood is within 12 units of the maximum value is within a bivariate 95% confidence region.
 We can see there is extensive uncertainty here, as most of this plot is within a 12 log-likelihood unit range of the maximum.
 
 We also see that the the log-likelihood surface does not appear to have a single mode.
-It is easier to see what is going on if we focus in on where the likelihood is highest.
+It is easier to see what is going on if we focus in on where the likelihood is highest: small values of $R$.
 
 ```{r}
 r_vec <- exp(seq(log(1e-4), log(0.02), length.out = 100))
@@ -256,7 +256,7 @@ The posterior distributions on $R$ exhibit rather low overlap, suggesting that $
 We can quantify this, if we like, by some measure of overlap of the posteriors.
 We might, for example, contemplate what percent  of the posterior on $R_{\text{US}}$ is above the 2.5th percentile of the posterior on $R_{\text{Canada}}$.
 We would then compute the 2.5th percentile of $R_{\text{Canada}}$, find that it is `r {unname(round(r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) |> quantile(probs = 0.025), 2))}`, and count the percent of samples of $R_{\text{US}}$ which are larger than this and find that it is `r {round(mean(r_df |> dplyr::filter(location == "US") |> dplyr::pull(r) >= r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) |> quantile(probs = 0.025)), 2) * 100}`%.
-Or we could do this the other way around, and ask what percent  of the posterior on $R_{\text{Canada}}$ is below the which is below the 97.5th percentile of the posterior on $R_{\text{US}}$.
+Or we could do this the other way around, and ask what percent  of the posterior on $R_{\text{Canada}}$ is below below the 97.5th percentile of the posterior on $R_{\text{US}}$.
 This is `r {round(mean(r_df |> dplyr::filter(location == "Canada") |> dplyr::pull(r) <= r_df |> dplyr::filter(location == "US") |> dplyr::pull(r) |> quantile(probs = 0.975)), 2) * 100}`%.
 
 These summaries are not entirely satisfying, as we have both an arbitrary reference quantile and an asymmetric measure.


### PR DESCRIPTION
This PR
1. Amends the likelihood surface explainer to be more explicit about what the shape of the likelihood is and how that drives the convergence issues.
2. Fills in several leaps in logic in the explanation of "how much do these $R$ distributions overlap?"
3. Removes out-of-date text about divergent transitions.

This should resolve the issues with clarity that @cherz4 raised in #7.
