### PR TITLE
Avoid side-effects when testing the code locally

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -10,3 +10,7 @@ library(testthat)
 library(nbbp)
 
 test_check("nbbp")
+
+if (file.exists("src")) {
+  unlink("src", recursive = TRUE)
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -10,7 +10,3 @@ library(testthat)
 library(nbbp)
 
 test_check("nbbp")
-
-if (file.exists("src")) {
-  unlink("src", recursive = TRUE)
-}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,9 @@
+withr::defer(
+  {
+    debug_src <- file.path("..", "..", "src")
+    if (file.exists(debug_src)) {
+      unlink(debug_src, recursive = TRUE)
+    }
+  },
+  testthat::teardown_env()
+)


### PR DESCRIPTION
When trying to test #22 locally, I ran into a cryptic issues where errors were being raised by the should-be-defunct Lognormal hyperparameters being absent from the tests.

Some sleuthing reveals that `devtools::test()`, via `devtools::load_all()` will build a local "debug" version of the stan code to test. This creates a directory `/src` with some `.h` (and such) files in it from building the stan bits. If this directory already exists, it appears that its contents are used, whereas if it does not exist, it is built. This appears to have led to the version of the stan code being tested being out of sync with the actual stan code.

This PR purges `/src` after every `devtools::test()` call.

Pros:
- No cryptic out-of-sync problems.
- No need for human intervention to purge `/src` every time the stan code is changed

Cons:
- Testing now takes 30-ish seconds each time (on my machine)

I have decided that, despite the stan model being pretty stable at this point, the con of inconvenience is vastly outweighed by the pro of banishing cryptic problems.