### PR TITLE
Issue 31: change initial point for zero-finder

### DIFF
--- a/inst/stan/nbbp_homogenous.stan
+++ b/inst/stan/nbbp_homogenous.stan
@@ -9,10 +9,10 @@ functions {
 
   // Use Newton's method in-stan to solve Equation 4 in https://doi.org/10.1016/j.jtbi.2011.10.039
   real solve_exn(real r_eff, real dispersion, int nsteps) {
-    if (r_eff < 1.0) {
+    if (r_eff <= 1.0) {
       return 1.0;
     }
-    real p = 0.5;
+    real p = 1 / r_eff; // Initial guess -- exact for Geometric offspring distribution
     for (i in 1:nsteps) {
       p = p - exn_prob_zero_fun(p, r_eff, dispersion) /
         exn_prob_zero_fun_grad(p, r_eff, dispersion);


### PR DESCRIPTION
This small PR closes #31 .

Only change in this PR is moving the initial guess of the zero-finder to the known solution for geometric offspring distributions $1/R$ (when $R> 1$), which is a better starting point than $0.5$