### PR TITLE
Tiny vignette tweaks

### DIFF
--- a/vignettes/model_adequacy.Rmd
+++ b/vignettes/model_adequacy.Rmd
@@ -70,11 +70,11 @@ set.seed(42)
 
 nchains <- length(pneumonic_plague_inf)
 npred <- 100
-posterior_predictive <- data.frame(
-  r = unlist(rstan::extract(fit_inf, "r_eff")),
-  k = unlist(rstan::extract(fit_inf, "dispersion")),
-  index = 1:10000
-) |>
+
+posterior_predictive <- rstan::extract(fit_inf, pars = c("r_eff", "dispersion")) |>
+  as.data.frame() |>
+  dplyr::rename(r = r_eff, k = dispersion) |>
+  dplyr::mutate(index = row_number()) |>
   filter(index %in% sample.int(10000, npred)) |>
   mutate(
     chain_size = purrr::map2(
@@ -333,11 +333,11 @@ We can get the pooled model's prediction on what differences would look like bet
 ```{r}
 nchains <- length(measles_pooled)
 npred <- 100
-pooled_predictive <- data.frame(
-  r = unlist(rstan::extract(pooled, "r_eff")),
-  k = unlist(rstan::extract(pooled, "dispersion")),
-  index = 1:10000
-) |>
+
+pooled_predictive <- rstan::extract(pooled, pars = c("r_eff", "dispersion")) |>
+  as.data.frame() |>
+  dplyr::rename(r = r_eff, k = dispersion) |>
+  dplyr::mutate(index = row_number()) |>
   filter(index %in% sample.int(10000, npred)) |>
   mutate(
     chain_size = purrr::map2(

--- a/vignettes/nbbp.Rmd
+++ b/vignettes/nbbp.Rmd
@@ -95,7 +95,6 @@ We can see even greater uncertainty about $k$, which is typical in practice with
 
 While `rstan` provides some basic plotting capabilities, this is not the only way to do so.
 Here we extract and plot things ourselves directly with ggplot, though we could also use the `bayesplot` package which has many nice visualizations.
-Plots show us
 ```{r}
 par_df <- rstan::extract(fit, pars = c("r_eff", "dispersion", "p_0", "exn_prob")) |>
   as.data.frame()


### PR DESCRIPTION
This PR
- Restructures the `rstan::extract` call in the _Advanced data_ vignette, resolving #50. As discussed there, it appears rstan's assurances of reproducibly randomized ordering meant that we did not have a bug, but now we won't worry.
- Fixes a typo in the _nbbp_ vignette