### PR TITLE
JOSS compliance

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -79,6 +79,7 @@
   year = {2025},
   note = {R package version 0.1.1.9000},
   url = {https://github.com/epiverse-trace/epichains},
+  doi = {10.32614/cran.package.epichains}
 }
 
 @article{tran2024estimating,
@@ -111,7 +112,8 @@
   year = {2011},
   volume = {3},
   pages = {5--10},
-  url = {https://journal.r-project.org/articles/RJ-2011-002/}
+  url = {https://journal.r-project.org/articles/RJ-2011-002/},
+  doi = {10.32614/rj-2011-002}
 }
 
 @manual{r2021r,
@@ -120,7 +122,8 @@
   organization={R Foundation for Statistical Computing},
   address={Vienna, Austria},
   year={2021},
-  url={https://www.R-project.org/}
+  url={https://www.R-project.org/},
+  doi={10.32614/r.manuals}
 }
 
 @Misc{stan2025rstan,
@@ -129,6 +132,7 @@
     note = {R package version 2.32.7},
     year = {2025},
     url = {https://mc-stan.org/},
+    doi = {10.32614/cran.package.rstantools}
   }
 
 @Manual{gabry2026rstantools,

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -34,57 +34,64 @@ date: 12 Mar 2026
 # Summary
 
 During an infectious disease outbreak, each infected person, or "case," infects a certain number of other people, often zero.
-In a Galton-Watson branching process model of an outbreak, the number of onward infections per infector is drawn from a statistical distribution, such as the negative binomial, parameterised by the effective reproduction number $R$ and a concentration parameter $k$, such that the distribution has mean $R$ and variance $R + R^2/k$.
-Inferring the parameters of that distribution is important for forecasting the future of outbreaks and for determining what interventions are most appropriate.
-`nbbp` is an [R](https://www.r-project.org/) [@r2021r] package for Bayesian inference of negative binomial branching process parameters using final outbreak size data [@blumberg2013inference; @nishiura2012estimating].
-
-# Statement of need
+In a branching process model of an outbreak, the number of onward infections per infector is drawn from some "offspring" distribution, commonly the negative binomial, which is parameterised by the effective reproduction number $R$ and a concentration parameter $k$, yielding mean $R$ and variance $R + R^2/k$.
 
 Ideally, investigations of infectious disease outbreaks would yield a complete transmission tree, showing who infected whom.
 In practice, we often only have the final size of each outbreak.
-Methods to infer negative binomial branching process parameters from final sizes can suffer problems when outbreaks are small, when there are small numbers of outbreaks, and when outbreaks are large.
+Thus, inferring the parameters of the offspring distribution from final size data is important for calibrating outbreak responses and predicting future case burdens.
+`nbbp` is an [R](https://www.r-project.org/) [@r2021r] package providing Bayesian inference of negative binomial branching process parameters from such data [@blumberg2013inference; @nishiura2012estimating].
 
-Accurate analysis of small datasets requires Bayesian approaches because standard statistical guarantees like unbiasedness may not be useful when estimator variance are very large, and frequentist confidence intervals based on large-sample theory may be misleading or invalid.
-These distortions can affect probabilistic judgments on questions like "Is $R \leq 1$ or not?" which can be crucial for public health decision-making.
+# State of the field
 
-Analysis of large outbreaks requires explicit censoring and probabilistic conditioning to avoid drawing misleading conclusions.
-Galton-Watson branching processes assume that the offspring distribution is constant throughout every outbreak, which can be a good model of epidemic dynamics when outbreaks are new and small, but is inappropriate for large outbreaks, since these processes inevitably ends in:
+The R package [`epichains`](https://github.com/epiverse-trace/epichains) [@azam2025epichains] implements a variety of branching process models, including those without analytical solutions, with a focus on case data, and is tested via [`testthat`](https://testthat.r-lib.org/) [@wickham2011testthat].
+It provides likelihoods but generally leaves inference to the user.
+The Stan-based R package [`estRodis`](https://github.com/mwohlfender/estRodis) [@hodcroft2025estimating] implements Bayesian inference for negative binomial branching process models, but focuses on genomic data and requires a domain-specific mutation rate parameter [@hodcroft2025estimating; @tran2024estimating].
+
+# Statement of need
+
+Methods to infer negative binomial branching process parameters from final sizes can suffer problems when outbreaks are small, when there are small numbers of outbreaks, and when outbreaks are exceptionally large.
+
+For example, from 2015 to 2023, 7 cases of Borealpox were identified without evidence of onward, person-to-person transmission [@mooring2025six].
+The lack of outbreaks larger than a single case means the likelihood surface is pathological, converging to probability one as $R \to 0$ and $k \to 0$, making maximum likelihood estimation fraught.
+Further, there are not many observed outbreaks, _i.e._ the sample size is small.
+When the sample size is small, frequentist confidence intervals can be very wide and the variance of the maximum likelihood estimate large.
+
+Lastly, consider the 19 outbreaks (each containing at least two cases) analyzed by @nishiura2012estimating.
+While 18 of these contained no more than 42 cases, one contained 5009.
+Branching processes for final size data assume that the offspring distribution is constant throughout every outbreak, which can be a good model of epidemic dynamics when outbreaks are new and small, but is inappropriate for large outbreaks, as the only mathematical endpoints are:
 
 1. _extinction_, in which stochastic fade out leads to an outbreak with a finite number of cases, or
 2. _explosion_, in which super-critical growth leads to an outbreak of infinite size.
 
 In reality, no outbreak is truly infinite, and large, finite outbreaks typically signal that $R > 1$ initially but that $R$ fell over the course of the outbreak, for example, because of depletion of susceptibles or a public health intervention.
-However, naively asserting that a large outbreak went extinct implies that $R \approx 1$.
-Thus, to allow rational estimates for early-outbreak $R$, inference methods should allow users to assert that an outbreak would have been an explosion or would have been at least as large as it was.
-Conditioning on extinction can also induce a bimodal likelihood surface [@waxman2019sub], which complicates inference of whether $R \leq 1$ or $R > 1$.
+Thus, exceptionally large outbreaks are both informative and severe model violations.
 
-`nbbp` accounts for large outbreaks by allowing users to assert that each outbreak was one of:
+A general-purpose solution should enable the _absence_ of explosions to be treated as evidence that $R < 1$, while also allowing exceptionally large outbreaks to be appropriately informative observations.
+This requires that one does not condition the likelihood on extinction, which induces a likelihood surface containing both sub- and super-critical maxima [@waxman2019sub].
+Then, one can either:
+- treat an exceptionally large outbreak as an explosion, more or less asserting that the outbreak would have been an explosion absent the factors outside the model which suppressed $R$, or
+- (right-)censor the exceptionally large outbreak, in essence allowing the model to determine whether the outbreak would have been an explosion or not.
 
+As such, `nbbp` is designed to provide:
+1. rigorous Bayesian inference of final size data, which should be more robust in the face of pathological likelihood surfaces and small sample sizes, and
+2. flexible handling of exceptionally large outbreaks.
+
+# Software design
+
+## Software ecosystem
+
+`nbbp` uses [Stan](https://mc-Stan.org/) [@stan2026stan] for statistical inference, interfacing with R using [`Rstan`](https://mc-Stan.org/rstan/articles/rstan.html) [@stan2025rstan] and [`rstantools`](https://mc-Stan.org/rstantools/) [@gabry2026rstantools]. By providing standard `rstan` outputs, `nbbp` can be integrated into larger epidemiological analyses using this mature Bayesian software ecosystem. `nbbp`'s design is modular, enabling the addition of new models (e.g., extensions to time-series or geospatial modeling) that leveraging the underlying Stan codebase with minimal architecture changes. The package is extensively tested via `testthat`.
+
+## Support for censoring, partially observed outbreaks, and non-extinction
+
+For inference, `nbbp` accommodates a wide variety of observation processes for finite chain sizes as well as flexible handling for exceptionally large outbreaks.
+In total, it ecognizes four kinds of observed chain sizes as input:
 1. **Completely observed and extinct**, optionally of a minimum size. The exact number $c$ of cases in the outbreak is known, and outbreaks of size at least $C$ are observed. If all "outbreaks", including single infections, are reported, then $C = 1$. Otherwise, $C$ is the minimum outbreak size required for an outbreak to appear in the dataset.
 1. **Censored**. The number of cases is $c \geq C$.
 1. **Partially observed and extinct**. Each case in the outbreak has an independent probability $p$ of being observed, and $c$ cases are observed.
 1. An **explosion**, that is, an outbreak that grew (or would have grown) to infinite size.
 
-# Statement of the field
-
-The R package [`epichains`](https://github.com/epiverse-trace/epichains) [@azam2025epichains] implements a variety of branching process models, including those without analytical solutions.
-It provides likelihoods but generally leaves inference to the user.
-The Stan-based R package [`estRodis`](https://github.com/mwohlfender/estRodis) [@hodcroft2025estimating] implements Bayesian inference for negative binomial branching process models, but focuses on genomic data and requires a domain-specific mutation rate parameter [@hodcroft2025estimating; @tran2024estimating].
-
-Like `epichains`, `nbbp` focuses on case data, implements both outbreak size censoring and partially observed outbreaks in the likelihood, provides an R-based interface for outbreak size simulation, and is extensively tested via [`testthat`](https://testthat.r-lib.org/) [@wickham2011testthat].
-Like `estRodis`, `nbbp` is a Bayesian inference-focused package that leverages Stan and provides priors for $R$ and $k$, which by default are only weaky informative.
-
-Uniquely, `nbbp` provides flexible handling of large outbreaks, numerical safeguards for evaluating the censored probability mass of large outbreaks, and user control over numerical error when evaluating the probabilities of partially observed outbreaks.
-
-# Software design
-
-## Bayesian workflow
-
-`nbbp` uses [Stan](https://mc-Stan.org/) [@stan2026stan] for statistical inference, interfacing with R using [`Rstan`](https://mc-Stan.org/rstan/articles/rstan.html) [@stan2025rstan] and [`rstantools`](https://mc-Stan.org/rstantools/) [@gabry2026rstantools]. By providing standard `rstan` outputs, `nbbp` can be integrated into larger epidemiological analyses using this mature Bayesian software ecosystem. `nbbp`'s design is modular, enabling the addition of new models (e.g., extensions to time-series or geospatial modeling) that leveraging the underlying Stan codebase with minimal architecture changes.
-
-## Support for censoring, partially observed outbreaks, and non-extinction
-
-`nbbp` implements the the log-likelihood for a given dataset as:
+Accordingly, `nbbp` implements the log-likelihood for a given dataset as:
 
 $$
 \begin{aligned}
@@ -105,8 +112,8 @@ $$
 \text{Pr}(c \geq C \mid R, k) = 1 - \sum_{c=0}^{C-1} \text{Pr}(c \mid R, k)
 $$
 
-In implementing censoring, we discovered numerical instabilities in the probability mass function, which led to cumulative distribution function values that exceeded 1 (but by no more than about $10^{-12}$).
-`nbbp` implements two numerical safeguards that ensure bounded cumulative distribution function values.
+In implementing censoring, we discovered numerical instabilities in the probability mass function, which led to the RHS evaluating to less than 0 (but no smaller than about $-10^{-12}$).
+`nbbp` implements a hard safeguard to ensure the RHS is strictly nonnegative, and a soft safeguard to reduce the usage of the hard safeguard.
 
 The probabilities for partially observed outbreaks are defined as per @blumberg2013comparing:
 
@@ -115,7 +122,7 @@ $$
 $$
 
 where $\text{Pr}(c \mid x, p)$, the probability of observing $c$ cases given the true size $x$, is binomially distributed.
-These infinite sums in practice converge within reasonable tolerances. The package documentation describes optimizations that achieve small, user-specified tolerances at acceptable computational cost.
+Practically, these infinite sums converge within reasonable tolerances. The package documentation describes optimizations that achieve small, user-specified tolerances at acceptable computational cost.
 
 The probability $\text{Pr}(\mathcal{E} \mid R, k)$ is calculated using traditional branching process theory, derived by @nishiura2012estimating.
 
@@ -130,12 +137,7 @@ The probability $\text{Pr}(\mathcal{E} \mid R, k)$ is calculated using tradition
 
 # Research impact
 
-`nbbp` is an "off the shelf" analysis tool that enables rapid analysis of certain kinds of data common to infectious disease epidemiology.
-For example, from 2015 to 2023, 6 cases of Borealpox were identified without no evidence of onward, person-to-person transmission [@mooring2025six]. Because all observed "outbreaks" were size one, the likelihood surface is pathological, and traditional maximum likelihood analyses are fraught. `nbbp` provides robust posteriors for this data set and enables analyses of the sensitivity of posteriors to prior assumptions.
-
-`nbbp`'s likelihood surface visualization clarifies the need for Bayesian analysis.
-For example, most datasets included in `nbbp` have likelihood surfaces with minimal curvature with respect to $k$, and the `pneumonic_plauge` dataset has a multimodal likelihood surface.
-When only outbreaks of size one are present, as in the `borealpox` dataset, the likelihood surface converges to 1 for both $R = 0$ and $k = 0$.
+`nbbp` is an "off the shelf" analysis tool, enabling rapid analysis of final size data common to infectious disease epidemiology and providing both information and tools for judging the trustworthiness of the results.
 
 # AI usage disclosure
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -33,84 +33,58 @@ date: 12 Mar 2026
 
 # Summary
 
-`nbbp` is an extensible, inference-focused package for estimating the distribution of secondary cases caused per primary case, also known as the epidemiological offspring distribution.
-The offspring distribution is modelled as negative binomial, parameterised by the effective reproduction number $R$ and a concentration parameter $k$, such that the distribution has mean $R$ and variance $R + R^2/k$.
-Inference on these parameters is generated from final outbreak size data [@blumberg2013inference; @nishiura2012estimating].
-`nbbp` is designed to perform reliably even with small sample sizes.
-
-With small datasets, standard statistical guarantees like unbiasedness may not be useful, as estimator variance can be very large.
-Confidence intervals based on large-sample theory may be misleading or invalid.
-For example, from 2015 to 2023, 6 cases of Borealpox were identified without no evidence of onward, person-to-person transmission [@mooring2025six].
-In that example, only "outbreaks" of size one were observed, implying a pathological likelihood surface.
-Thus, small sample sizes affect making probabilistic judgments on questions like "Is $R \leq 1$ or not?" which can be crucial for public health decision-making.
-Such issues suggest two improvements.
-First, Bayesian approaches can alleviate problems with estimator variance and confidence intervals.
-Second, because the fact that an outbreak did not end (i.e., go extinct) "on its own" is itself useful evidence, inference should allow for outbreaks that go extinct.
-
-For statistical inference, `nbbp` uses [Stan](https://mc-Stan.org/) [@stan2026stan], capitalizing on a mature Bayesian statistical inference platform with a strong development community. In particular, `nbbp` leverages Stan's interoperability with [R](https://www.r-project.org/) [@r2021r], specifically using [`Rstan`](https://mc-Stan.org/rstan/articles/rstan.html) [@stan2025rstan] and [`rstantools`](https://mc-Stan.org/rstantools/) [@gabry2026rstantools].
+During an infectious disease outbreak, each infected person, or "case," infects a certain number of other people, often zero.
+In a Galton-Watson branching process model of an outbreak, the number of onward infections per infector is drawn from a statistical distribution, such as the negative binomial, parameterised by the effective reproduction number $R$ and a concentration parameter $k$, such that the distribution has mean $R$ and variance $R + R^2/k$.
+Inferring the parameters of that distribution is important for forecasting the future of outbreaks and for determining what interventions are most appropriate.
+`nbbp` is an [R](https://www.r-project.org/) [@r2021r] package for Bayesian inference of negative binomial branching process parameters using final outbreak size data [@blumberg2013inference; @nishiura2012estimating].
 
 # Statement of need
 
-To understand `nbbp`'s niche, it is useful to survey other tools in this space.
-The R package [`epichains`](https://github.com/epiverse-trace/epichains) [@azam2025epichains] is a broad and powerful toolkit for a variety of branching process models, including those without analytical solutions.
-It is primarily a utility which provides likelihoods but leaves inference to the user.
-The Stan-based R package [`estRodis`](https://github.com/mwohlfender/estRodis) [@hodcroft2025estimating] is a toolkit targeted at negative binomial branching process model inference from genomic data [@hodcroft2025estimating; @tran2024estimating].
-As such, its models require a domain-specific mutation rate parameter, to account for the complexities of applying the model to genomic data.
+Ideally, investigations of infectious disease outbreaks would yield a complete transmission tree, showing who infected whom.
+In practice, we often only have the final size of each outbreak.
+Methods to infer negative binomial branching process parameters from final sizes can suffer problems when outbreaks are small, when there are small numbers of outbreaks, and when outbreaks are large.
 
-Like `epichains`, `nbbp` focuses on case data, implements both outbreak size censoring and partially observed outbreaks in the likelihood, provides an R-based interface for outbreak size simulation, and is extensively tested via [`testthat`](https://testthat.r-lib.org/) [@wickham2011testthat].
-Like `estRodis`, `nbbp` is a Bayesian inference-focused package that leverages Stan and provides priors for $R$ and $k$, which by default are only weaky informative.
-Uniquely, `nbbp` provides flexible handling of large outbreaks for discriminating between the $R \leq 1$ and $R > 1$ cases via a multipartite data likelihood, numerical safeguards for evaluating the censored probability mass of large outbreaks, and user control over numerical error when evaluating the probabilities of partially observed outbreaks.
-Additionally, `nbbp` aims to be useful to practitioners by providing package data and vignettes that demonstrate how well it works and how trustworthy its inferences are.
-Results for both a grid-based simulation study and a test of the calibration of posterior credible intervals are available, enabling examination of both point estimate performance and coverage.
+Accurate analysis of small datasets requires Bayesian approaches because standard statistical guarantees like unbiasedness may not be useful when estimator variance are very large, and frequentist confidence intervals based on large-sample theory may be misleading or invalid.
+These distortions can affect probabilistic judgments on questions like "Is $R \leq 1$ or not?" which can be crucial for public health decision-making.
 
-# Key features of the `nbbp` package
-
-- **Comprehensive documentation**. Detailed guides and examples covering installation, usage, and interpretation of results.
-- **Stan integration**. Provides seamless interfaces to Stan for Bayesian inference, allowing users to estimate epidemiological parameters with robust uncertainty quantification. Includes tools for visualizing likelihood surfaces, aiding in model diagnostics and parameter exploration. Uses standard `rstan` outputs for ease of integration into larger epidemiological analyses.
-- **Simulation-tested settings**. Performance of Bayesian point and interval estimators using the default prior settings have been tested in simulation, helping users understand expected performance for their analyses over an epidemiologically important range of parameter space.
-- **Final size distribution functions in R style**. Implements functions for the final size distribution using familiar R conventions (`d`, `p`, `r` for density, etc.), making it easy to integrate with other R workflows. These functions facilitate tasks such as simulation, model checking, and custom inference procedures.
-- **Support for censoring, partially observed outbreaks, and non-extinction**. Handles censored data, partially observed, and non-extinct outbreaks, allowing for principled inference even when outbreaks are ongoing or data is incomplete.
-- **Extensibility**. Modular design enables the addition of new models (e.g., extensions to time-series or geospatial modeling) with minimal changes, leveraging the underlying Stan codebase.
-- **Package data**. `nbbp` provides six exemplar datasets of final size outbreak sizes, covering a range of data and parameter regimes, aiding workflow and analysis prototyping and experimentation [@blumberg2014detecting; @nigel2004assessment; @king2004measles; @cauchemez2014middle].
-
-# `nbbp` details
-
-## Using outbreak size and extinction as information in branching process inference
-
-A branching process is expected to be a good model of epidemic dynamics when outbreaks are new and small.
-In theory, for nearly all models, two limiting outcomes are possible:
+Analysis of large outbreaks requires explicit censoring and probabilistic conditioning to avoid drawing misleading conclusions.
+Galton-Watson branching processes assume that the offspring distribution is constant throughout every outbreak, which can be a good model of epidemic dynamics when outbreaks are new and small, but is inappropriate for large outbreaks, since these processes inevitably ends in:
 
 1. _extinction_, in which stochastic fade out leads to an outbreak with a finite number of cases, or
 2. _explosion_, in which super-critical growth leads to an outbreak of infinite size.
 
-In reality, no outbreak is truly infinite.
-If all cases in an outbreak are observed (or if the probability of observing a case is known), we can use the distribution of the sizes of observed outbreaks to infer the secondary case distribution [@blumberg2013inference].
-The outbreak size distribution given by @blumberg2013inference applies for both $R\leq1$ and $R>1$.
-Therefore, the absence of large outbreaks does not force `nbbp` to infer $R \leq 1$, since an outbreak may have had the potential for explosion but nonetheless faded out by chance.
-Note that, when inferring whether $R\leq1$ or $R>1$, it is desirable avoid conditioning on extinction, as is sometimes done when analyzing the super-critical case in isolation [@nishiura2012estimating], because conditioning induces a bimodal likelihood surface [@waxman2019sub].
+In reality, no outbreak is truly infinite, and large, finite outbreaks typically signal that $R > 1$ initially but that $R$ fell over the course of the outbreak, for example, because of depletion of susceptibles or a public health intervention.
+However, naively asserting that a large outbreak went extinct implies that $R \approx 1$.
+Thus, to allow rational estimates for early-outbreak $R$, inference methods should allow users to assert that an outbreak would have been an explosion or would have been at least as large as it was.
+Conditioning on extinction can also induce a bimodal likelihood surface [@waxman2019sub], which complicates inference of whether $R \leq 1$ or $R > 1$.
 
-In analyses of outbreak size data, it is typical to assume that all outbreaks in a dataset are produced by the same $R$ and $k$ values.
-However, over longer outbreaks, this approximation may break down.
-For example, $R$ likely changes due to factors such as interventions or behavior changes.
-This presents a problem for inference: under branching process theory, large but extinct outbreaks can can only occur if $R \approx 1$.
-In theory, a large, but extinct, outbreak is vanishingly unlikely if $R \ll 1$, since outbreaks are typically small in this regime, and also vanishingly unlikely if $R \gg 1$, when outbreaks explode.
-In reality, a large but finite outbreak typically signals that $R > 1$ initially but that $R$ fell over the course of the outbreak.
-Naively asserting that a large outbreak was finite therefore introduces strong constaints on inferred values for $R$.
+`nbbp` accounts for large outbreaks by allowing users to assert that each outbreak was one of:
 
-`nbbp` provides flexible handling of large outbreaks that can mitigate this challenge.
-First, `nbbp` allows users to flag an outbreak size as _censored_, that is, that the outbreak was at least as large as the reported size, rather than exactly that size.
-Second, `nbbp` allows users to input outbreaks of size `Inf`, that is, to assert that an outbreak (which in reality had some finite size) would have grown super-critically at its original $R$.
+1. **Completely observed and extinct**, optionally of a minimum size. The exact number $c$ of cases in the outbreak is known, and outbreaks of size at least $C$ are observed. If all "outbreaks", including single infections, are reported, then $C = 1$. Otherwise, $C$ is the minimum outbreak size required for an outbreak to appear in the dataset.
+1. **Censored**. The number of cases is $c \geq C$.
+1. **Partially observed and extinct**. Each case in the outbreak has an independent probability $p$ of being observed, and $c$ cases are observed.
+1. An **explosion**, that is, an outbreak that grew (or would have grown) to infinite size.
 
-## Data likelihood
+# Statement of the field
 
-The underlying probabilistic model of `nbbp` can generate a multipartite dataset consisting of
+The R package [`epichains`](https://github.com/epiverse-trace/epichains) [@azam2025epichains] implements a variety of branching process models, including those without analytical solutions.
+It provides likelihoods but generally leaves inference to the user.
+The Stan-based R package [`estRodis`](https://github.com/mwohlfender/estRodis) [@hodcroft2025estimating] implements Bayesian inference for negative binomial branching process models, but focuses on genomic data and requires a domain-specific mutation rate parameter [@hodcroft2025estimating; @tran2024estimating].
 
-1. **Completely observed, extinct outbreaks**, optionally of a minimum size. The exact number $c$ of cases in the outbreak is known, and outbreaks of size at least $C$ are observed. If all "outbreaks", including single infections, are reported, then $C = 1$. Otherwise, $C$ is the minimum outbreak size required for an outbreak to appear in the dataset.
-1. **Censored outbreaks**. The number of cases is $c \geq C$.
-1. **Partially observed, extinct outbreaks**. Each case in the outbreak has an independent probability $p$ of being observed, and $c$ cases are observed.
-1. **Explosions**, that is, outbreaks that grew (or would have grown) to infinite size.
+Like `epichains`, `nbbp` focuses on case data, implements both outbreak size censoring and partially observed outbreaks in the likelihood, provides an R-based interface for outbreak size simulation, and is extensively tested via [`testthat`](https://testthat.r-lib.org/) [@wickham2011testthat].
+Like `estRodis`, `nbbp` is a Bayesian inference-focused package that leverages Stan and provides priors for $R$ and $k$, which by default are only weaky informative.
 
-The log-likelihood for a given dataset is:
+Uniquely, `nbbp` provides flexible handling of large outbreaks, numerical safeguards for evaluating the censored probability mass of large outbreaks, and user control over numerical error when evaluating the probabilities of partially observed outbreaks.
+
+# Software design
+
+## Bayesian workflow
+
+`nbbp` uses [Stan](https://mc-Stan.org/) [@stan2026stan] for statistical inference, interfacing with R using [`Rstan`](https://mc-Stan.org/rstan/articles/rstan.html) [@stan2025rstan] and [`rstantools`](https://mc-Stan.org/rstantools/) [@gabry2026rstantools]. By providing standard `rstan` outputs, `nbbp` can be integrated into larger epidemiological analyses using this mature Bayesian software ecosystem. `nbbp`'s design is modular, enabling the addition of new models (e.g., extensions to time-series or geospatial modeling) that leveraging the underlying Stan codebase with minimal architecture changes.
+
+## Support for censoring, partially observed outbreaks, and non-extinction
+
+`nbbp` implements the the log-likelihood for a given dataset as:
 
 $$
 \begin{aligned}
@@ -121,97 +95,59 @@ $$
 \end{aligned}
 $$
 
-where $\mathcal{I}_1$ are the indices of the completely observed outbreaks, $\mathcal{I}_2$ are the censored outbreaks, $\mathcal{I}_3$ are the partially observed outbreaks, $\mathcal{I}_4$ are the explosions, and $\mathcal{E}$ is extinction.
+where $c_i$ is the true size of the $i$-th outbreak, $C_i$ is the censoring or truncation limit, $\mathcal{I}_1$ are the indices of the completely observed (but potentially truncated) outbreaks, $\mathcal{I}_2$ are the censored outbreaks, $\mathcal{I}_3$ are the partially observed outbreaks, $\mathcal{I}_4$ are the explosions, and $\mathcal{E}$ is extinction.
+
 The probabilities $\text{Pr}(c \mid R, k)$ are defined as per @blumberg2013inference.
+
 The censored probabilities are:
 
 $$
 \text{Pr}(c \geq C \mid R, k) = 1 - \sum_{c=0}^{C-1} \text{Pr}(c \mid R, k)
 $$
 
-The probabilities $\text{Pr}(c \mid R, k, p)$ for partially observed outbreaks are defined as per @blumberg2013comparing:
+In implementing censoring, we discovered numerical instabilities in the probability mass function, which led to cumulative distribution function values that exceeded 1 (but by no more than about $10^{-12}$).
+`nbbp` implements two numerical safeguards that ensure bounded cumulative distribution function values.
+
+The probabilities for partially observed outbreaks are defined as per @blumberg2013comparing:
 
 $$
 \text{Pr}(c \mid R, k, p) = \sum_{x=c}^\infty \text{Pr}(c \mid x, p) \text{Pr}(x \mid R, k)
 $$
 
 where $\text{Pr}(c \mid x, p)$, the probability of observing $c$ cases given the true size $x$, is binomially distributed.
-We discuss below how `nbbp` computes these nominally infinite sums in practice.
+These infinite sums in practice converge within reasonable tolerances. The package documentation describes optimizations that achieve small, user-specified tolerances at acceptable computational cost.
 
-The probability $\text{Pr}(\mathcal{E} \mid R, k)$ is calculated using traditional branching process theory as derived by @nishiura2012estimating.
+The probability $\text{Pr}(\mathcal{E} \mid R, k)$ is calculated using traditional branching process theory, derived by @nishiura2012estimating.
 
-## Numerical instabilities and their mitigations
+## User friendlieness
 
-In implementing censoring, we discovered numerical instabilities in the probability mass function (PMF).
-As no closed form is available, `nbbp` computes the cumulative distribution function (CDF) by brute force summation of the PMF.
-Different representations of the PMF led to different levels of sensitivity, but all forms explored led to PMFs which could sum to values greater than one for finite outbreak sizes.
-In practice, the CDF exceeded one by no more than $10^{-12}$.
-The solution implemented in `nbbp` has two components.
+`nbbp` aims to be useful to practitioners by providing:
 
-First, we re-write the negative binomial branching process final size PMF using Stan's built in negative binomial log-density function `neg_binomial_2_lpmf`.
-Let $\mathrm{NegativeBinomial}(x; R, k)$ be the negative binomial PMF evaluated at $x$ with mean $R$ and concentration $k$.
-The PMF of the final size distribution can be written
+- **Likelihood surface visualization**, aiding in model diagnostics and parameter exploration, and showing clearly the value of Bayesian over frequentist inference for certain datasets.
+- **Package data**: six exemplar datasets of final size outbreak sizes, covering a range of data and parameter regimes [@blumberg2014detecting; @nigel2004assessment; @king2004measles; @cauchemez2014middle].
+- **Simulation-tested settings**. Performance of Bayesian estimators using the default prior settings have been tested in simulation, including grid-based simulation study and a test of the calibration of posterior credible intervals, helping users understand expected performance over a range of parameter space.
+- **Maximum likelihood inference** (MLE). `nbbp` was designed in part because of MLE's sensitivity to pathologies common to the likelihood surfaces of these types of datasets. `nbbp` provides some MLE methods, with enhanced numerical safeguards. Nevertheless, MLE results should be used only for data exploration and for comparison to Bayesian results.
 
-$$
-\mathrm{Pr}(c \mid R, k) = -\log(c) + \mathrm{NegativeBinomial}(c - 1; R c, k c)
-$$
+# Research impact
 
-Compared to alternative representations of the likelihood (for example, directly translating equation 9 of @blumberg2013inference to Stan code), using `neg_binomial_2_lpmf` appeared to lead to the lowest frequency of CDF values exceeding 1.
+`nbbp` is an "off the shelf" analysis tool that enables rapid analysis of certain kinds of data common to infectious disease epidemiology.
+For example, from 2015 to 2023, 6 cases of Borealpox were identified without no evidence of onward, person-to-person transmission [@mooring2025six]. Because all observed "outbreaks" were size one, the likelihood surface is pathological, and traditional maximum likelihood analyses are fraught. `nbbp` provides robust posteriors for this data set and enables analyses of the sensitivity of posteriors to prior assumptions.
 
-Second, when an invalid CDF value (i.e., greater than 1) is encountered, `nbbp` dynamically rescales the CDF in Stan.
-Let $c_\mathrm{max}$ be the maximum outbreak size for which we need to evaluate $\mathrm{Pr}(c \mid R, k)$.
-If $\sum_{x=1}^{c_\mathrm{max}} \mathrm{Pr}(x \mid R, k) > 1$, then we instead use:
-
-$$
-\widetilde{\mathrm{Pr}}(c \mid R, k) = \frac{1 - \epsilon}{\sum_{x = 1}^{c_\mathrm{max}} \mathrm{Pr}(x \mid R, k)} \cdot \mathrm{Pr}(c \mid R, k)
-$$
-
-As such, the rescaled CDF is safely less than one.
-In practice, we use Stan's [`machine_precision()`](https://mc-Stan.org/docs/Stan-users-guide/floating-point.html) for $\epsilon$.
-Note that given the modularly implemented, multipartite likelihood, $\widetilde{\mathrm{Pr}}$ is only used in the portions of the likelihood involving the CDF of completely observed outbreaks (i.e., censoring and size-conditioning).
-
-## Maximum likelihood inference and confidence intervals
-
-While the primary use of `nbbp` is Bayesian inference, it also offers maximum likelihood estimation (MLE), leveraging Stan's optimization routines.
-Given that the likelihood surface can exhibit a number of pathologies, to which numerical MLE has proven sensitive, it is included in the package for development and exploratory purposes only.
-Datasets often display likelihood surfaces with minimal curvature with respect to $k$ (e.g., most datasets included in `nbbp`) and occasionally they display multimodal likelihood surfaces (e.g., the `pneumonic_plague` dataset in `nbbp`).
-When only outbreaks of size one are present (e.g., the `borealpox` dataset), the likelihood surface converges to 1 for both $R = 0$ and $k = 0$.
-As both parameters must be positive, the effect is that MLE runs converge to either small $R$ and arbitrary $k$, or vice-versa.
-Point and interval estimates from MLE should be examined with due care to assess quality and trustworthiness.
-
-To provide context on possible convergence issues with the optimizer, multiple independent runs are performed and summarized.
-By default, runs from independent (random) starting values are performed until either 10 successfully converged replicates (as reported by Stan) are performed or a total of 50 attempts have been made.
-
-For confidence intervals, `nbbp` implements by default an adaptive approach, choosing between either likelihood profiling or the parametric bootstrap.
-In this way, better intervals can be obtained than by either approach alone, as the parametric bootstrap generally was observed to provide better coverage than (univariate) likelihood profiling, except in the $R \approx 1$ regime.
-Both approaches allow for confidence intervals to be obtained even in otherwise pathological datasets with only outbreaks of size one.
-It is worth noting that the Bayesian credible intervals are generally narrower, and their coverage performance is less sensitive to sample size, than these confidence intervals.
-
-## Adaptive bounds for infinite sums
-
-The likelihood of partially observed outbreaks is an infinite sum, but in practice the sum often converges within reasonable tolerances much faster:
-
-$$
-\begin{aligned}
-\text{Pr}(c \mid R, k, p)
-&= \sum_{x=c}^{m} \text{Pr}(c \mid x, p) \text{Pr}(x \mid R, k) + \sum_{x=m+1}^\infty \text{Pr}(c \mid x, p) \text{Pr}(x \mid R, k)\\
-&= \sum_{x=c}^{m} \text{Pr}(c \mid x, p) \text{Pr}(x \mid R, k) + \epsilon
-\end{aligned}
-$$
-
-As described in detail in the package documentation, it is possible to choose $m$ such that the error $\epsilon$ is no larger than some prespecified small tolerance.
-Numerical experiments show that default package settings keep typical errors on the order of $9 \times 10^{-10}$.
+`nbbp`'s likelihood surface visualization clarifies the need for Bayesian analysis.
+For example, most datasets included in `nbbp` have likelihood surfaces with minimal curvature with respect to $k$, and the `pneumonic_plauge` dataset has a multimodal likelihood surface.
+When only outbreaks of size one are present, as in the `borealpox` dataset, the likelihood surface converges to 1 for both $R = 0$ and $k = 0$.
 
 # AI usage disclosure
 
 No AI was used in the preparation of this manuscript.
-AI language models, accessed through GitHub Copilot, were used to assist in the development of `nbbp`, including for generating code, debugging, refactoring, and copy-editing of text.
-Everything written and/or suggested by AI was thoroughly reviewed by one or more humans, and often extensively revised by those humans.
-The following models may have been used by CoPilot:
-Anthropic's Claude (Haiku 4.5; Opus 4.1, 4.5, and 4.6, including fast mode variants thereof; Sonnet 3.5, 3.7, 4, 4.5, 4.6, including thinking variants thereof),
-Google's Gemini (2.0, 2.5, 3, and 3.1, including flash and pro variants thereof),
-OpenAI's GPT (4, 5, 5.1, 5.2, 5.3, and 5.4, including o, mini, max, and codex variants thereof, and higher-order combination variants thereof),
-OpenAI's o (o1, o3, and o4, including mini variants thereof),
+
+AI language models, accessed through GitHub Copilot, were used to assist in the development of `nbbp`, including for generating code, debugging, refactoring, and copy-editing.
+Everything written or suggested by AI was reviewed and revised by humans.
+The following models may have been used by Copilot:
+Anthropic's Claude (Haiku 4.5; Opus 4.1, 4.5, and 4.6, including fast mode variants; Sonnet 3.5, 3.7, 4, 4.5, 4.6, including thinking variants),
+Google's Gemini (2.0, 2.5, 3, and 3.1, including flash and pro variants),
+OpenAI's GPT (4, 5, 5.1, 5.2, 5.3, and 5.4, including o, mini, max, codex, and higher-order combination variants),
+OpenAI's o (o1, o3, and o4, including mini variants),
 and
 xAI's Grok (Code Fast 1).
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -91,7 +91,7 @@ In total, it ecognizes four kinds of observed chain sizes as input:
 1. **Partially observed and extinct**. Each case in the outbreak has an independent probability $p$ of being observed, and $c$ cases are observed.
 1. An **explosion**, that is, an outbreak that grew (or would have grown) to infinite size.
 
-Accordingly, `nbbp` implements the log-likelihood for a given dataset as:
+Accordingly, `nbbp`'s implementation of the log-likelihood for a given dataset can be written as:
 
 $$
 \begin{aligned}

--- a/vignettes/details.Rmd
+++ b/vignettes/details.Rmd
@@ -96,8 +96,29 @@ When brute-force computing the CDF (by summing the PMF), sometimes it evaluates 
 In practice, this appears to happen exclusively for $R < 1$ and the maximum seems to be less than $1 + 10^{-12}$.
 This is noticeable when censoring observations, where for chain size $c$ we need $\text{Pr}(C >= c) = 1 - \text{CDF}(c - 1)$.
 When the CDF exceeds one, this is negative and MCMC cannot appropriately explore the $R < 1$ region.
-To avoid these issues, the `stan` model code checks that the CDF does not exceed 1 over the range it needs to be evaluated.
-If it ever exceeds 1, we rescale so that the maximum CDF is [`1.0 - machine_precision()`](https://mc-stan.org/docs/stan-users-guide/floating-point.html).
+
+`nbbp` takes two approaches to mitigating this problem.
+First, we use Stan's built-in negative binomial log-density function `neg_binomial_2_lpmf` to compute the final size PMF.
+Let $\mathrm{NegativeBinomial}(x; R, k)$ be the negative binomial PMF evaluated at $x$ with mean $R$ and concentration $k$.
+The PMF of the final size distribution can be written
+
+$$
+\mathrm{Pr}(c \mid R, k) = -\log(c) + \mathrm{NegativeBinomial}(c - 1; R c, k c)
+$$
+
+Compared to alternative representations of the likelihood (for example, directly translating equation 9 of Blumberg & Lloyd-Smith (2013) to Stan code), using `neg_binomial_2_lpmf` appeared to lead to the lowest frequency of CDF values exceeding 1.
+
+Second, when an invalid CDF value (i.e., greater than 1) is encountered, `nbbp` dynamically rescales the CDF in Stan.
+Let $c_\mathrm{max}$ be the maximum outbreak size for which we need to evaluate $\mathrm{Pr}(c \mid R, k)$.
+If $\sum_{x=1}^{c_\mathrm{max}} \mathrm{Pr}(x \mid R, k) > 1$, then we instead use:
+
+$$
+\widetilde{\mathrm{Pr}}(c \mid R, k) = \frac{1 - \epsilon}{\sum_{x = 1}^{c_\mathrm{max}} \mathrm{Pr}(x \mid R, k)} \cdot \mathrm{Pr}(c \mid R, k)
+$$
+
+As such, the rescaled CDF is safely less than one.
+In practice, we use Stan's [`machine_precision()`](https://mc-Stan.org/docs/Stan-users-guide/floating-point.html) for $\epsilon$.
+Note that given the modularly implemented, multipartite likelihood, $\widetilde{\mathrm{Pr}}$ is only used in the portions of the likelihood involving the CDF of completely observed outbreaks (i.e., censoring and size-conditioning).
 
 ## Incompletely observed chains
 

--- a/vignettes/details.Rmd
+++ b/vignettes/details.Rmd
@@ -118,7 +118,7 @@ $$
 
 As such, the rescaled CDF is safely less than one.
 In practice, we use Stan's [`machine_precision()`](https://mc-Stan.org/docs/Stan-users-guide/floating-point.html) for $\epsilon$.
-Note that given the modularly implemented, multipartite likelihood, $\widetilde{\mathrm{Pr}}$ is only used in the portions of the likelihood involving the CDF of completely observed outbreaks (i.e., censoring and size-conditioning).
+Note that due to the implementation of the likelihood in Stan, $\widetilde{\mathrm{Pr}}$ is only used for likelihoods of (completely observed) censored and size-conditioned outbreaks, not partially-observed outbreaks.
 
 ## Incompletely observed chains
 


### PR DESCRIPTION
- 🚧  Go through the excised material to spin off as needed Issues for anything that needs porting to the docs.
- ✅ Reorganized into canonical sections
- ✅ Reduced from 2403 to 1529 words (36% reduction)
  - I'm using `pandoc --strip-comments -t plain paper/paper.md | wc -w`
  - This differs somewhat from their counting method (which started at 2528)
  - I think we should aim for 30-40% reduction. JOSS says articles should be 750-1750 words. We were asked for 40% reduction (i.e., to 1516, right in the middle of that range). A 30% reduction would be 1682 (at the higher end of that range).
- ✅ Missing DOIs added

Resolves #66 